### PR TITLE
fix env var discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install -r requirements.txt
 
 1. Create a .env file in the opensearch directory containing the following:
 ```bash
-OPENSEARCH_INITIAL_PASSWORD=<password>
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=<password>
 OPENSEARCH_HOST=localhost
 OPENSEARCH_PORT=9200
 S3_BUCKET_NAME=<bucket-name> 

--- a/opensearch/create_client.py
+++ b/opensearch/create_client.py
@@ -23,7 +23,7 @@ def create_client():
         raise ValueError('Please set the environment variables OPENSEARCH_HOST and OPENSEARCH_PORT')
     
     if host == 'localhost':
-        auth = ('admin', os.getenv('OPENSEARCH_INITIAL_PASSWORD'))
+        auth = ('admin', os.getenv('OPENSEARCH_INITIAL_ADMIN_PASSWORD'))
 
         ca_certs_path = certifi.where()
         # Create the client with SSL/TLS enabled, but hostname verification disabled.

--- a/opensearch/docker-compose.yml
+++ b/opensearch/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2 # Nodes eligibile to serve as cluster manager
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_PASSWORD} # Sets the demo admin user password when using demo configuration (for OpenSearch 2.12 and later)
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)
@@ -36,7 +35,6 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_PASSWORD}
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
This PR changes the environment variable for the opensearch password in the docker compose, README and client script