### PR TITLE
Update download dockets

### DIFF
--- a/opensearch/DownloadDockets.sh
+++ b/opensearch/DownloadDockets.sh
@@ -4,6 +4,6 @@ aws s3 sync s3://mirrulations/DEA/DEA-2016-0015/text-DEA-2016-0015/comments ./do
 aws s3 sync s3://mirrulations/HHS/HHS-OS-2018-0008/text-HHS-OS-2018-0008/comments ./docket-samples/HHS-OS-2018-0008/text-HHS-OS-2018-0008/comments
 aws s3 sync s3://mirrulations/FTC/FTC-2019-0054/text-FTC-2019-0054/comments ./docket-samples/FTC-2019-0054/text-FTC-2019-0054/comments
 aws s3 sync s3://mirrulations/FDA/FDA-2021-N-1088/text-FDA-2021-N-1088/comments ./docket-samples/FDA-2021-N-1088/text-FDA-2021-N-1088/comments
-aws s3 sync s3://mirrulations/HHS/HHS-OSR-2019-0007/text-HHS-OSR-2019-0007/comments ./docket-samples/HHS-OSR-2019-0007/text-HHS-OSR-2019-0007/comments
+aws s3 sync s3://mirrulations/HHS/HHS-OCR-2019-0007/text-HHS-OCR-2019-0007/comments ./docket-samples/HHS-OCR-2019-0007/text-HHS-OCR-2019-0007/comments
 aws s3 sync s3://mirrulations/HHS/HHS-OS-2019-0014/text-HHS-OS-2019-0014/comments ./docket-samples/HHS-OS-2019-0014/text-HHS-OS-2019-0014/comments
 

--- a/opensearch/DownloadDockets.sh
+++ b/opensearch/DownloadDockets.sh
@@ -1,9 +1,9 @@
-aws s3 sync s3://mirrulations/CMS/CMS-2012-0031 ./docket-samples/CMS-2012-0031
-aws s3 sync s3://mirrulations/HHS/HHS-OS-2016-0014 ./docket-samples/HHS-OS-2016-0014
-aws s3 sync s3://mirrulations/DEA/DEA-2016-0015 ./docket-samples/DEA-2016-0015
-aws s3 sync s3://mirrulations/HHS/HHS-OS-2018-0008 ./docket-samples/HHS-OS-2018-0008
-aws s3 sync s3://mirrulations/FTC/FTC-2019-0054 ./docket-samples/FTC-2019-0054
-aws s3 sync s3://mirrulations/FDA/FDA-2021-N-1088 ./docket-samples/FDA-2021-N-1088
-aws s3 sync s3://mirrulations/HHS/HHS-OSR-2019-0007 ./docket-samples/HHS-OSR-2019-0007
-aws s3 sync s3://mirrulations/HHS/HHS-OS-2019-0014 ./docket-samples/HHS-OS-2019-0014
+aws s3 sync s3://mirrulations/CMS/CMS-2012-0031/text-CMS-2012-0031/comments ./docket-samples/CMS-2012-0031/text-CMS-2012-0031/comments
+aws s3 sync s3://mirrulations/HHS/HHS-OS-2016-0014/text-HHS-OS-2016-0014/comments ./docket-samples/HHS-OS-2016-0014/text-HHS-OS-2016-0014/comments
+aws s3 sync s3://mirrulations/DEA/DEA-2016-0015/text-DEA-2016-0015/comments ./docket-samples/DEA-2016-0015/text-DEA-2016-0015/comments
+aws s3 sync s3://mirrulations/HHS/HHS-OS-2018-0008/text-HHS-OS-2018-0008/comments ./docket-samples/HHS-OS-2018-0008/text-HHS-OS-2018-0008/comments
+aws s3 sync s3://mirrulations/FTC/FTC-2019-0054/text-FTC-2019-0054/comments ./docket-samples/FTC-2019-0054/text-FTC-2019-0054/comments
+aws s3 sync s3://mirrulations/FDA/FDA-2021-N-1088/text-FDA-2021-N-1088/comments ./docket-samples/FDA-2021-N-1088/text-FDA-2021-N-1088/comments
+aws s3 sync s3://mirrulations/HHS/HHS-OSR-2019-0007/text-HHS-OSR-2019-0007/comments ./docket-samples/HHS-OSR-2019-0007/text-HHS-OSR-2019-0007/comments
+aws s3 sync s3://mirrulations/HHS/HHS-OS-2019-0014/text-HHS-OS-2019-0014/comments ./docket-samples/HHS-OS-2019-0014/text-HHS-OS-2019-0014/comments
 


### PR DESCRIPTION
Change DownloadDockets.sh to only download the comment text of each docket
to prevent downloading unnecessary data. Fixes a typo in one of the docket IDs.