### PR TITLE
Query output

### DIFF
--- a/opensearch/query.py
+++ b/opensearch/query.py
@@ -35,12 +35,23 @@ dockets = response["aggregations"]["docketId_stats"]["buckets"]
 index_stats = client.count(index=index_name)
 total_documents = index_stats["count"]
 
-# Print the report
-print("Report: Matches and Total Comments Per Docket")
+# Create a list of dockets in json format that contains the docketId, docketTitle, the number of total comments, and the number of matching comments out of total comments
+dockets = [
+    {
+        "docketID": docket["key"],
+        "doc_count": docket["doc_count"],
+        "matching_comments": docket["matching_comments"]["doc_count"]
+    }
+    
+    for docket in dockets
+    ]
+
+# Print the list of dockets
+print("Dockets:")
 for docket in dockets:
-    docket_id = docket["key"]
-    total_comments = docket["doc_count"]
-    matching_comments = docket["matching_comments"]["doc_count"]
-    print(f"docketId: {docket_id}, Matches: {matching_comments}, Total Comments: {total_comments}")
+    if docket['matching_comments']['doc_count'] > 0:
+        print(f"\nDocket ID: {docket['docketID']}")
+        print(f"Total comments: {docket['doc_count']}")
+        print(f"Matching comments: {docket['matching_comments']}/{docket['doc_count']}")
 
 print(f"\nTotal number of documents in the index: {total_documents}")

--- a/opensearch/query.py
+++ b/opensearch/query.py
@@ -1,8 +1,17 @@
 from create_client import create_client
+import sys
 
 client = create_client()
 
 index_name = "comments"
+
+# Get the search term from the command line
+if len(sys.argv) < 2:
+    print("Please provide a search term")
+    sys.exit(1)
+
+search_term = sys.argv[1]
+print(f"Searching for: {search_term}")
 
 query = {
     "size": 0,  # No need to fetch individual documents
@@ -16,7 +25,7 @@ query = {
                 "matching_comments": {
                     "filter": {
                         "match": {
-                            "commentText": "drug"
+                            "commentText": search_term
                         }
                     }
                 }


### PR DESCRIPTION
This modifies the query.py file to package the dockets in a list of dictionaries of each docket. The file then outputs the dockets that have comments that match the search term and leaves out the ones that don't (they are still saved in the list). The new output is much more similar to what was represented in the sprint 2 presentation. It leaves out the docket title, as that would be pulled from the SQL database at a later point. Also adds the ability to provide a search term as an argument in the terminal.