### PR TITLE
fix syntax error

### DIFF
--- a/queries/query.py
+++ b/queries/query.py
@@ -269,8 +269,7 @@ def search(search_params):
         return json.dumps(ret)
 
 
-if __name__ 
-"__main__":
+if __name__ == "__main__":
     query_params = {
         "searchTerm": "gun",
         "pageNumber": 0,


### PR DESCRIPTION
There was a missing `==` sign that was lost during a merge conflict.