### PR TITLE
Allow for the pagination table to be deleted weekly

### DIFF
--- a/sql/DeletePagination.py
+++ b/sql/DeletePagination.py
@@ -1,0 +1,34 @@
+import psycopg 
+import os 
+import sys
+from dotenv import load_dotenv
+import datetime
+
+def _drop_table_last_week(conn: psycopg.Connection, table_name: str):
+    """
+    Drop the contnets of the table from the previous week 
+    """
+
+    try:
+        with conn.cursor() as cur:
+            # Check if the table exists
+            cur.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{table_name}');")
+            exists = cur.fetchone()[0]
+
+            if not exists:
+                print(f"Table '{table_name}' does not exist")
+                return
+
+            # Get the current date and time
+            now = datetime.datetime.now()
+
+            # Calculate the date one week ago
+            one_week_ago = now - datetime.timedelta(weeks=1)
+            # Delete records older than one week
+            cur.execute(f"DELETE FROM {table_name} WHERE created_at < %s;", (one_week_ago,))
+            conn.commit()
+            print(f"Records older than one week in table '{table_name}' deleted successfully")
+    except Exception as e:
+        print(f"An error occurred while deleting records from table '{table_name}': {e}")
+
+

--- a/tests/test_dropPagination.py
+++ b/tests/test_dropPagination.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import MagicMock
+import os
+import sys
+
+# Ensure project root is in the path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sql.DeletePagination import _drop_table_last_week
+
+
+@pytest.fixture
+def mock_conn():
+    mock_cursor = MagicMock()
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    return mock_conn, mock_cursor
+
+
+def test_table_does_not_exist(mock_conn):
+    conn, cursor = mock_conn
+    cursor.fetchone.return_value = (False,)
+
+    _drop_table_last_week(conn, "nonexistent_table")
+
+    cursor.execute.assert_called_once_with(
+        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'nonexistent_table');"
+    )
+    conn.commit.assert_not_called()
+
+
+def test_table_exists_and_deletes_old_records(mock_conn):
+    conn, cursor = mock_conn
+    cursor.fetchone.return_value = (True,)
+
+    _drop_table_last_week(conn, "test_table")
+
+    assert cursor.execute.call_count == 2
+    assert "DELETE FROM test_table WHERE created_at <" in cursor.execute.call_args_list[1][0][0]
+    conn.commit.assert_called_once()
+
+
+def test_error_handling(mock_conn, capsys):
+    conn, cursor = mock_conn
+    cursor.fetchone.side_effect = Exception("DB error")
+
+    _drop_table_last_week(conn, "test_table")
+
+    captured = capsys.readouterr()
+    assert "An error occurred while deleting records from table 'test_table'" in captured.out


### PR DESCRIPTION
Deleting the pagination table weekly (only keeps the previous week) to save on space, the delta between deletes can be changed if need be (not sure if one week is good enough)