### PR TITLE
Refactored summary table into 2 new tables

### DIFF
--- a/sql/CreateAbstractsTable.py
+++ b/sql/CreateAbstractsTable.py
@@ -1,0 +1,26 @@
+from CreateTables import create_abstracts_table
+from dotenv import load_dotenv
+import psycopg
+import os
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    dbname = os.getenv("POSTGRES_DB")
+    username = os.getenv("POSTGRES_USER")
+    password = os.getenv("POSTGRES_PASSWORD")
+    host = os.getenv("POSTGRES_HOST")
+    port = os.getenv("POSTGRES_PORT")
+
+    conn_params = {
+        "dbname": dbname,
+        "user": username,
+        "password": password,
+        "host": host,
+        "port": port,
+    }
+    try:
+        conn = psycopg.connect(**conn_params)
+    except psycopg.Error as e:
+        print(e)
+    create_abstracts_table(conn)

--- a/sql/CreateTables.py
+++ b/sql/CreateTables.py
@@ -182,8 +182,7 @@ def create_abstracts_table(conn: psycopg.Connection):
     query = """ 
     CREATE TABLE abstracts (
         docket_id VARCHAR(50) NOT NULL REFERENCES dockets(docket_id),
-        abstract TEXT,
-        modify_date TIMESTAMP WITH TIME ZONE NOT NULL
+        abstract TEXT
     );
     """
     _create_table(conn, query, "abstracts")
@@ -195,8 +194,7 @@ def create_htm_summaries_table(conn: psycopg.Connection):
     CREATE TABLE htm_summaries (
         summary_id SERIAL PRIMARY KEY,
         docket_id VARCHAR(50) NOT NULL REFERENCES dockets(docket_id),
-        summary TEXT,
-        posted_date TIMESTAMP WITH TIME ZONE NOT NULL
+        summary TEXT
     );
     """
     _create_table(conn, query, "htm_summaries")

--- a/sql/CreateTables.py
+++ b/sql/CreateTables.py
@@ -176,17 +176,30 @@ def create_agencies_table(conn: psycopg.Connection):
     );
     """
     _create_table(conn, query, "agencies")
-    
-def create_summaries_table(conn: psycopg.Connection):
-    # other fields can be added to this to support additional fields like AI Summary
+
+
+def create_abstracts_table(conn: psycopg.Connection):
     query = """ 
-    CREATE TABLE summaries (
+    CREATE TABLE abstracts (
         docket_id VARCHAR(50) NOT NULL REFERENCES dockets(docket_id),
-        abstract TEXT, 
-        summary TEXT
+        abstract TEXT,
+        modify_date TIMESTAMP WITH TIME ZONE NOT NULL
     );
     """
-    _create_table(conn, query, "summaries")
+    _create_table(conn, query, "abstracts")
+
+
+def create_htm_summaries_table(conn: psycopg.Connection):
+    # other fields can be added to this to support additional fields like AI Summary
+    query = """ 
+    CREATE TABLE htm_summaries (
+        summary_id SERIAL PRIMARY KEY,
+        docket_id VARCHAR(50) NOT NULL REFERENCES dockets(docket_id),
+        summary TEXT,
+        posted_date TIMESTAMP WITH TIME ZONE NOT NULL
+    );
+    """
+    _create_table(conn, query, "htm_summaries")
 
 
 def insert_agencies_data(conn: psycopg.Connection, file_path: str):
@@ -248,7 +261,8 @@ def main():
     create_comments_table(conn)
     create_agencies_table(conn)
     create_stored_results_table(conn)
-    create_summaries_table(conn)
+    create_htm_summaries_table(conn)
+    create_abstracts_table(conn)
 
     # Insert data into the agencies table
     insert_agencies_data(conn, "agencies.txt")

--- a/sql/DropTables.py
+++ b/sql/DropTables.py
@@ -50,6 +50,12 @@ def drop_stored_results_table(conn: psycopg.Connection):
 def drop_agencies_table(conn: psycopg.Connection):
     _drop_table(conn, "agencies")
 
+def drop_abstracts_table(conn: psycopg.Connection):
+    _drop_table(conn, "abstracts")
+
+def drop_htm_summaries_table(conn: psycopg.Connection):
+    _drop_table(conn, "htm_summaries")
+
 def main():
     load_dotenv()
 
@@ -76,6 +82,8 @@ def main():
     drop_dockets_table(conn)
     drop_documents_table(conn)
     drop_agencies_table(conn)
+    drop_abstracts_table(conn)
+    drop_htm_summaries_table(conn)
 
     conn.close()
 

--- a/sql/ResetDatabase.py
+++ b/sql/ResetDatabase.py
@@ -3,7 +3,9 @@ from DropTables import (
     drop_dockets_table, 
     drop_documents_table,
     drop_agencies_table,
-    drop_stored_results_table
+    drop_stored_results_table,
+    drop_abstracts_table,
+    drop_htm_summaries_table,
 )
 from CreateTables import (
     create_comments_table,
@@ -11,6 +13,8 @@ from CreateTables import (
     create_documents_table,
     create_stored_results_table,
     create_agencies_table,
+    create_abstracts_table,
+    create_htm_summaries_table,
     insert_agencies_data
 )
 from dotenv import load_dotenv
@@ -47,6 +51,8 @@ def main():
     drop_dockets_table(conn)
     drop_stored_results_table(conn)
     drop_agencies_table(conn)
+    drop_abstracts_table(conn)
+    drop_htm_summaries_table(conn)
 
     print("\nRecreating tables...")
     create_dockets_table(conn)
@@ -54,6 +60,8 @@ def main():
     create_comments_table(conn)
     create_stored_results_table(conn)
     create_agencies_table(conn)
+    create_abstracts_table(conn)
+    create_htm_summaries_table(conn)
 
     print("\nInserting data into the agencies table...")
     insert_agencies_data(conn, "agencies.txt")


### PR DESCRIPTION
- Updated summaries table to derive 2 new tables, **htm_summaries** and **abstracts**
- Each table contains the summary field along with the docket_id
- Table scripts updated to reflect this
- Scripts to generate solely Abstracts/HTM_Summaries tables included